### PR TITLE
Enable artifact caching and zinc workers.

### DIFF
--- a/pants.ini
+++ b/pants.ini
@@ -1,2 +1,10 @@
 [DEFAULT]
 pants_version: 0.0.68
+local_artifact_cache: %(pants_bootstrapdir)s/artifact_cache
+
+[cache.bootstrap]
+read_from: ["%(local_artifact_cache)s"]
+write_to: ["%(local_artifact_cache)s"]
+
+[compile.zinc]
+worker_count: 4


### PR DESCRIPTION
JVM tool bootstrapping and shading is costly and shouldn't be incurred on each run. This adds `pants.ini` configuration to enable zinc workers and bootstrap artifact caching, drastically reducing `pants` runtime for the `pants300files` benchmark.

before:

```
[illuminati pants300files (master)]$ ./pants clean-all && time ./pants compile src
INFO] Detected git repository at /Users/kwilson/dev/pants300files on branch master

18:31:25 00:00 [main]
               (To run a reporting server: ./pants server)
18:31:25 00:00   [setup]
18:31:25 00:00     [parse]
               Executing tasks in goals: clean-all
18:31:25 00:00   [clean-all]
18:31:25 00:00     [ng-killall]INFO] killing nailgun server pid=44891

18:31:25 00:00     [clean-all]
18:31:25 00:00     [kill-pantsd]
18:31:25 00:00   [complete]
               SUCCESS
INFO] Detected git repository at /Users/kwilson/dev/pants300files on branch master

18:31:26 00:00 [main]
               (To run a reporting server: ./pants server)
18:31:26 00:00   [setup]
18:31:26 00:00     [parse]
               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> deferred-sources -> jvm-platform-validate -> gen -> resolve -> compile
18:31:26 00:00   [bootstrap]
18:31:26 00:00     [bootstrap-jvm-tools]
18:31:26 00:00   [imports]
18:31:26 00:00     [ivy-imports]
18:31:26 00:00   [unpack-jars]
18:31:26 00:00     [unpack-jars]
18:31:26 00:00   [deferred-sources]
18:31:26 00:00     [deferred-sources]
18:31:26 00:00   [jvm-platform-validate]
18:31:26 00:00     [jvm-platform-validate]WARN] No default jvm platform is defined.

                   Invalidated 1 target.
18:31:26 00:00   [gen]
18:31:26 00:00     [thrift]
18:31:26 00:00     [protoc]
18:31:26 00:00     [antlr]
18:31:26 00:00     [ragel]
18:31:26 00:00     [jaxb]
18:31:26 00:00     [wire]
18:31:26 00:00   [resolve]
18:31:26 00:00     [ivy]
18:31:26 00:00       [bootstrap-nailgun-server]
18:31:26 00:00   [compile]
18:31:26 00:00     [compile-jvm-prep-command]
18:31:26 00:00       [jvm_prep_command]
18:31:26 00:00     [compile]
18:31:26 00:00     [zinc]
18:31:26 00:00       [isolation-zinc-pool-bootstrap]
                   Invalidated 1 target.
                   [1/1] Compiling 300 zinc sources in 1 target (src:src).
18:31:26 00:00       [compile]

18:31:26 00:00         [bootstrap-scalac_2_10]
18:31:27 00:01         [bootstrap-compiler-interface]
18:31:27 00:01         [bootstrap-sbt-interface]
                     Invalidated 1 target.
18:31:28 00:02         [bootstrap-zinc]
18:31:28 00:02         [bootstrap-jar-tool]
18:31:29 00:03         [jar-tool]
18:31:30 00:04         [bootstrap-jarjar]
18:31:31 00:05         [shade-zinc]
18:32:07 00:41         [zinc]
                       [info] Compiling 300 Java sources to /Users/kwilson/dev/pants300files/.pants.d/compile/zinc/_._._.1._._._._._._._/src.src/f97ed330bb77/classes...
                       [info] Compile success at Jan 19, 2016 6:32:09 PM [2.463s]

18:32:09 00:43     [jvm-dep-check]
18:32:09 00:43   [complete]
               SUCCESS

real    0m44.148s
user    0m42.224s
sys     0m4.849s
```

after:

```
[illuminati pants300files (kwlzn/enable_caching)]$ ./pants clean-all && time ./pants compile src
INFO] Detected git repository at /Users/kwilson/dev/pants300files on branch kwlzn/enable_caching

18:30:35 00:00 [main]
               (To run a reporting server: ./pants server)
18:30:35 00:00   [setup]
18:30:35 00:00     [parse]
               Executing tasks in goals: clean-all
18:30:35 00:00   [clean-all]
18:30:35 00:00     [ng-killall]INFO] killing nailgun server pid=44460

18:30:36 00:01     [clean-all]
18:30:36 00:01     [kill-pantsd]
18:30:36 00:01   [complete]
               SUCCESS
INFO] Detected git repository at /Users/kwilson/dev/pants300files on branch kwlzn/enable_caching

18:30:36 00:00 [main]
               (To run a reporting server: ./pants server)
18:30:36 00:00   [setup]
18:30:36 00:00     [parse]
               Executing tasks in goals: bootstrap -> imports -> unpack-jars -> deferred-sources -> gen -> jvm-platform-validate -> resolve -> compile
18:30:36 00:00   [bootstrap]
18:30:36 00:00     [bootstrap-jvm-tools]
18:30:36 00:00   [imports]
18:30:36 00:00     [ivy-imports]
18:30:36 00:00   [unpack-jars]
18:30:36 00:00     [unpack-jars]
18:30:36 00:00   [deferred-sources]
18:30:36 00:00     [deferred-sources]
18:30:36 00:00   [gen]
18:30:36 00:00     [thrift]
18:30:36 00:00     [protoc]
18:30:36 00:00     [antlr]
18:30:36 00:00     [ragel]
18:30:36 00:00     [jaxb]
18:30:36 00:00     [wire]
18:30:36 00:00   [jvm-platform-validate]
18:30:36 00:00     [jvm-platform-validate]WARN] No default jvm platform is defined.

                   Invalidated 1 target.
18:30:36 00:00   [resolve]
18:30:36 00:00     [ivy]
18:30:36 00:00       [cache].
18:30:36 00:00   [compile]
18:30:36 00:00     [compile-jvm-prep-command]
18:30:36 00:00       [jvm_prep_command]
18:30:36 00:00     [compile]
18:30:36 00:00     [zinc]
18:30:36 00:00       [isolation-zinc-pool-bootstrap]
                   Invalidated 1 target.
                   [1/1] Compiling 300 zinc sources in 1 target (src:src).
18:30:36 00:00       [compile]

18:30:36 00:00         [cache].
18:30:36 00:00         [cache].
18:30:36 00:00         [cache].
18:30:36 00:00         [cache].
                     Using cached artifacts for 1 target.
18:30:37 00:01         [zinc]
                       [info] Compiling 300 Java sources to /Users/kwilson/dev/pants300files/.pants.d/compile/zinc/_._._.1._._._._._._._/src.src/f97ed330bb77/classes...
                       [info] Compile success at Jan 19, 2016 6:30:39 PM [2.365s]

18:30:40 00:04     [jvm-dep-check]
18:30:40 00:04   [complete]
               SUCCESS

real    0m4.059s
user    0m0.992s
sys     0m0.325s
```
